### PR TITLE
Fix LIS bug

### DIFF
--- a/packages/ivi/src/vdom/reconciler.ts
+++ b/packages/ivi/src/vdom/reconciler.ts
@@ -986,7 +986,8 @@ function lis(a: number[]): number[] {
       j = result[n];
       if (a[j] < k) {
         p[i] = j;
-        result[++n] = i;
+        if (!(i === 1 && a[0] === -1)) ++n
+        result[n] = i;
       } else {
         u = 0;
         v = n;


### PR DESCRIPTION
The `lis` function has a bug when the first item is new.

Currently, `lis([-1, 1])` returns `[0, 1]` instead of `[1]`. Actually, an initial -1 always results in an extra `0`.

This may not matter for ivi, but your repo is as far as I'm concerned the canonical LIS implementation in JS, and having at least this PR here lets me document the problem for me and probably others.

I went for `!(i === 1 && a[0] === -1)` rather than `i !== 1 || a[0] !== -1` for clarity, not sure if one is faster than the other.

See here for a [live demo with a few tests](https://flems.io/#0=N4IgZglgNgpgziAXAbVAOwIYFsZJAOgAsAXLKEAGhAGMB7NYmBvEAXwvW10RCgjnzEEVOgybE8ouMQAEARxkBeGQAcAOmg0wAHitoAnWWACuaasQj0ZAIwwATABQZEMtMazWY+5AF0AlC5uHl6+MsAaMjIA9FEydjDWxgDmSV4A3BEyUrIqSjIY+HB81DAOfhlokTEy+vDGULL8MhBo0hgMEBiMdvlw+ZUwWCrEAJ75+voYY8S0qrUAbuLNrcTtFl2WlQDuEMSEMgDCtADqNhjUANYtSTLSBjD4mdk1dQ2B7p7ePnm+FZGwskqygADH8ZADmnlQZkIcZ3sF9GCIfN4Z8kTBZAArVHpDSZWpwerEZDA74gsFgAwyBxpSEAHny+FgaCSe1pAGp2RA-GFMpFnhc8hhkBAfGDIhAwNTBQA+GQAWgAjDzwpVIurMXlKnKlTIAPwvQkNZBob4uJXi9WS6nCzHfBkXFV89WRFQiskyTGWl0EonITmmvIQb0yVgyGBQOAwXlql2RYxQkOReZairOl1bQjQaMOBMM+ZO2NxyKa5S5mTsmQFmQyuWKpNWqVOZC+412+0yR0x4vFhPKTWV+vpuNhiNR7s9l0p-sNyKsYdzvFFl3WhyChnC1vE4w+fwTyerhNy4GFycut2ivJb5AJ+UyRVihfq+fLuPXndBhsv4vf58yZ3VGO0aqi61SRHIDhqCA8rynqUF+ABsQSk2EBKIoIKnuqYHyJB0HygAhPBiFxtUaAwcRi5FtUv4vpk06Gn6pppmqmbZtS2oYfuDHGmR8oevMlr0W68yPmqtFqrUxDGPolRbhU4k6HohgyCYZgWFYkDaDAjjOK4HwhP4OJfBOzy5MoBRFBAJRlGC1Rbs0fQtG0HRdNpvT9OGQyjOMkzTLMKgLEsTmrC56nbLs+xHKctiXNctwzLUjxqs8W5GaEyi-DCGKuImWWNLlaqwkZ6KyCiekIiVnrFUukTXqSBWRJS+jUrSqEbkyTCsoQHJcph-L0NInZCu6lqrrKCrKlxJZajWE36txxKBuaQ6vqutodl2IE9heHpek+q74Q4qHocoioyAAZOd+QkmS6ETX4PIBk+16BsowbDqOkbAU+fYyNCr7JqmNU9qxsDUnmVZ9T2pbgxWkM1nWs7NE2m6vMS7YyA6UOTr9A73kjn3jltZ5Vnke0A8+T7iQeTbrtd767tjcaHrNJ5Tdt7pXmjN4Kveokk7+k4M5+VMfc6YbEUBXHYRBUEwXBIAIVRSHI9Sx13WzxPRCrst4YRisUVhsS8Ybgva6GmTU6TygvaJmSgzmHF-VDL0wfxgl5MJ-MW5oEkYtJslo-JlAgFGsDmJsCA8AATIgioAJxsBwICYDgeD4Jiwg0PQjDMDwEBDAYsjALYdgUCpEBaXYYZgPotBYDIADk+BRHwAhCI3S4APLWJiMDmPg4j6BA8AOCX9jl5p2msH4+BNQAouchAOA4JpcOXbd7oocpbbQDgAAZtw5MgACTAKnMCsPvk+mBH9BlFre9t6vpIPfg8QwCo89yMYGCRi--hnRP34C-Cg0d-Czw-l-H+f84CgL5krF0wC4HIGjuXAALOXAAbBA9+MBP7f1-v-Ek5dFTl3AYg9UyDV5oIQR1FkexZ4wBgf-ZUQCHDP2QAAZgwaQ8h-h6FdSYSwuB0dKGRGocgTBMgeEyFoQ+N+UDCGwNXlwwBRZJFkJkeQjBuClEiPgbQtR4iZCSOkUqHRMi9H4OgUQlBRj1FII4SAqRliLFWMUTY5RxCtHGPYZw6RRjy5KmsQQgxyAtEUOBlUWIAVaDWFgFgPohAvAwH8S49xCjIFePCQo9JKD3G0OkTgzxYS7Gr0ieXPxGjnEFK0YEqpoTbEqNQY0yhM8NAdN9rQfA+hTBlCXCHMO-cwpRxAIqdBiBgRJ04GnHg+BqBwCzqIXOEgeBsB8FQPgaALhR1QCnLgeBaBwBUP3EO0lyA8BIMQFQcBEAxFMCoC4SQFn1yiMc051AAAC6D8DAnwIqd5Jz+4ZyzqMU5eA4DUGHsMDZVAL54AADIAEkADKbAgA) (edit: tweaked for clarity).