### PR TITLE
"prevSibling" -> "previousSibling"

### DIFF
--- a/packages/ivi/src/index.ts
+++ b/packages/ivi/src/index.ts
@@ -165,7 +165,7 @@ export const nodeGetLastChild = /*@__PURE__*/getDescriptor(nodeProto, "lastChild
 /** `Node.prototype.getNextSibling` */
 export const nodeGetNextSibling = /*@__PURE__*/getDescriptor(nodeProto, "nextSibling")!.get!;
 /** `Node.prototype.getPrevSibling` */
-export const nodeGetPrevSibling = /*@__PURE__*/getDescriptor(nodeProto, "prevSibling")!.get!;
+export const nodeGetPrevSibling = /*@__PURE__*/getDescriptor(nodeProto, "previousSibling")!.get!;
 /** `Node.prototype.setTextContent` */
 export const nodeSetTextContent = /*@__PURE__*/getDescriptor(nodeProto, "textContent")!.set!;
 /** `Element.prototype.className` */


### PR DESCRIPTION
@localvoid unbreaks global init. (broke with the tpl below)

```js
  return () => htm`
    <div class="app">
      <div class="counter">${count()}</div>
      <button @click=${inc}>Increment</button>
      <form>
        <input type="text" *value=${value} @input=${setValue}>
      </form>
    </div>
  `;
```